### PR TITLE
ev3dev: refactor attribute read/writes

### DIFF
--- a/ev3dev/lego_port.go
+++ b/ev3dev/lego_port.go
@@ -6,7 +6,6 @@ package ev3dev
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -46,68 +45,37 @@ func LegoPortFor(port, driver string) (*LegoPort, error) {
 	return &LegoPort{id: id}, err
 }
 
-func (p *LegoPort) writeFile(path, data string) error {
-	return ioutil.WriteFile(path, []byte(data), 0)
-}
-
 // Modes returns the available modes for the LegoPort.
 func (p *LegoPort) Modes() ([]string, error) {
-	if p.err != nil {
-		return nil, p.Err()
-	}
-	b, err := ioutil.ReadFile(fmt.Sprintf(LegoPortPath+"/%s/"+modes, p))
-	if err != nil {
-		return nil, fmt.Errorf("ev3dev: failed to read port modes: %v", err)
-	}
-	return strings.Split(string(chomp(b)), " "), err
+	return stringSliceFrom(attributeOf(p, modes))
 }
 
 // Mode returns the currently selected mode of the LegoPort.
 func (p *LegoPort) Mode() (string, error) {
-	if p.err != nil {
-		return "", p.Err()
-	}
-	b, err := ioutil.ReadFile(fmt.Sprintf(LegoPortPath+"/%s/"+mode, p))
-	if err != nil {
-		return "", fmt.Errorf("ev3dev: failed to read port mode: %v", err)
-	}
-	return string(chomp(b)), err
+	return stringFrom(attributeOf(p, mode))
 }
 
 // SetMode sets the mode of the LegoPort.
-func (p *LegoPort) SetMode(mode string) *LegoPort {
+func (p *LegoPort) SetMode(m string) *LegoPort {
 	if p.err != nil {
 		return p
 	}
-	err := p.writeFile(fmt.Sprintf(LegoPortPath+"/%s/"+mode, p), mode)
-	if err != nil {
-		p.err = fmt.Errorf("ev3dev: failed to set port mode: %v", err)
-	}
+	p.err = setAttributeOf(p, mode, m)
 	return p
 }
 
 // SetDevice sets the device of the LegoPort.
-func (p *LegoPort) SetDevice(dev string) *LegoPort {
+func (p *LegoPort) SetDevice(d string) *LegoPort {
 	if p.err != nil {
 		return p
 	}
-	err := p.writeFile(fmt.Sprintf(LegoPortPath+"/%s/"+setDevice, p), dev)
-	if err != nil {
-		p.err = fmt.Errorf("ev3dev: failed to set port device: %v", err)
-	}
+	p.err = setAttributeOf(p, setDevice, d)
 	return p
 }
 
 // Status returns the current status of the LegoPort.
 func (p *LegoPort) Status() (string, error) {
-	if p.err != nil {
-		return "", p.Err()
-	}
-	b, err := ioutil.ReadFile(fmt.Sprintf(LegoPortPath+"/%s/"+status, p))
-	if err != nil {
-		return "", fmt.Errorf("ev3dev: failed to read port status: %v", err)
-	}
-	return string(chomp(b)), err
+	return stringFrom(attributeOf(p, status))
 }
 
 // ConnectedTo returns a description of the device attached to p in the form

--- a/ev3dev/power_supply.go
+++ b/ev3dev/power_supply.go
@@ -4,17 +4,21 @@
 
 package ev3dev
 
-import (
-	"fmt"
-	"io/ioutil"
-	"math"
-	"strconv"
-)
-
 // PowerSupply represents a handle to a the ev3 power supply controller.
-// The zero value is useable, reading from the legoev3-battery driver.
-// Using another string value will
+// The zero value is usable, reading from the legoev3-battery driver.
+// Using another string value will read from the device of that name.
 type PowerSupply string
+
+// powerDevice is used to fake a Device. The Type and Err methods
+// do not have meaningful semantics.
+type powerDevice struct {
+	PowerSupply
+}
+
+// Path returns the power-supply sysfs path.
+func (p PowerSupply) Path() string { return PowerSupplyPath }
+
+func (powerDevice) Type() string { panic("ev3dev: unexpected call of powerDevice Type") }
 
 // String satisfies the fmt.Stringer interface.
 func (p PowerSupply) String() string {
@@ -24,72 +28,39 @@ func (p PowerSupply) String() string {
 	return string(p)
 }
 
+// Err always returns nil since the power device does not support call chains.
+func (powerDevice) Err() error { return nil }
+
 // Voltage returns voltage measured from the power supply in volts.
 func (p PowerSupply) Voltage() (float64, error) {
-	b, err := ioutil.ReadFile(fmt.Sprintf(PowerSupplyPath+"/%s/"+voltageNow, p))
-	if err != nil {
-		return math.NaN(), fmt.Errorf("ev3dev: failed to read voltage: %v", err)
-	}
-	v, err := strconv.ParseFloat(string(chomp(b)), 64)
-	if err != nil {
-		return math.NaN(), fmt.Errorf("ev3dev: failed to parse voltage: %v", err)
-	}
-	return v * 1e-6, nil
+	v, err := float64From(attributeOf(powerDevice{p}, voltageNow))
+	return v * 1e-6, err
 }
 
 // VoltageMin returns the minimum design voltage for the power supply in volts.
 func (p PowerSupply) VoltageMin() (float64, error) {
-	b, err := ioutil.ReadFile(fmt.Sprintf(PowerSupplyPath+"/%s/"+voltageMinDesign, p))
-	if err != nil {
-		return math.NaN(), fmt.Errorf("ev3dev: failed to read voltage minimum: %v", err)
-	}
-	v, err := strconv.ParseFloat(string(chomp(b)), 64)
-	if err != nil {
-		return math.NaN(), fmt.Errorf("ev3dev: failed to parse voltage minimum: %v", err)
-	}
-	return v * 1e-6, nil
+	v, err := float64From(attributeOf(powerDevice{p}, voltageMinDesign))
+	return v * 1e-6, err
 }
 
 // VoltageMax returns the maximum design voltage for the power supply in volts.
 func (p PowerSupply) VoltageMax() (float64, error) {
-	b, err := ioutil.ReadFile(fmt.Sprintf(PowerSupplyPath+"/%s/"+voltageMaxDesign, p))
-	if err != nil {
-		return math.NaN(), fmt.Errorf("ev3dev: failed to read voltage maximum: %v", err)
-	}
-	v, err := strconv.ParseFloat(string(chomp(b)), 64)
-	if err != nil {
-		return math.NaN(), fmt.Errorf("ev3dev: failed to parse voltage maximum: %v", err)
-	}
-	return v * 1e-6, nil
+	v, err := float64From(attributeOf(powerDevice{p}, voltageMaxDesign))
+	return v * 1e-6, err
 }
 
 // Current returns the current drawn from the power supply in milliamps.
 func (p PowerSupply) Current() (float64, error) {
-	b, err := ioutil.ReadFile(fmt.Sprintf(PowerSupplyPath+"/%s/"+currentNow, p))
-	if err != nil {
-		return math.NaN(), fmt.Errorf("ev3dev: failed to read current: %v", err)
-	}
-	v, err := strconv.ParseFloat(string(chomp(b)), 64)
-	if err != nil {
-		return math.NaN(), fmt.Errorf("ev3dev: failed to parse current: %v", err)
-	}
-	return v * 1e-3, nil
+	v, err := float64From(attributeOf(powerDevice{p}, currentNow))
+	return v * 1e-3, err
 }
 
 // Technology returns the battery technology of the power supply.
 func (p PowerSupply) Technology() (string, error) {
-	b, err := ioutil.ReadFile(fmt.Sprintf(SensorPath+"/%p/"+batteryTechnology, p))
-	if err != nil {
-		return "", fmt.Errorf("ev3dev: failed to read battery type: %v", err)
-	}
-	return string(chomp(b)), err
+	return stringFrom(attributeOf(powerDevice{p}, batteryTechnology))
 }
 
-// Type returns the battery technology of the power supply.
+// Type returns the battery type of the power supply.
 func (p PowerSupply) Type() (string, error) {
-	b, err := ioutil.ReadFile(fmt.Sprintf(SensorPath+"/%p/"+batteryType, p))
-	if err != nil {
-		return "", fmt.Errorf("ev3dev: failed to read battery type: %v", err)
-	}
-	return string(chomp(b)), err
+	return stringFrom(attributeOf(powerDevice{p}, batteryType))
 }

--- a/ev3dev/servo_motor.go
+++ b/ev3dev/servo_motor.go
@@ -6,8 +6,6 @@ package ev3dev
 
 import (
 	"fmt"
-	"io/ioutil"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -52,10 +50,6 @@ func ServoMotorFor(port, driver string) (*ServoMotor, error) {
 	return &ServoMotor{id: id}, err
 }
 
-func (m *ServoMotor) writeFile(path, data string) error {
-	return ioutil.WriteFile(path, []byte(data), 0)
-}
-
 // Commands returns the available commands for the ServoMotor.
 func (m *ServoMotor) Commands() []string {
 	return []string{
@@ -81,119 +75,68 @@ func (m *ServoMotor) Command(comm string) *ServoMotor {
 		m.err = fmt.Errorf("ev3dev: command %q not available for %s (available:%q)", comm, m, avail)
 		return m
 	}
-	err := m.writeFile(fmt.Sprintf(ServoMotorPath+"/%s/"+command, m), comm)
-	if err != nil {
-		m.err = fmt.Errorf("ev3dev: failed to issue servo-motor command: %v", err)
-	}
+	m.err = setAttributeOf(m, command, comm)
 	return m
 }
 
-// MaxPulseSetpoint returns the current max pulse set point value for the ServoMotor.
+// MaxPulseSetpoint returns the current max pulse setpoint value for the ServoMotor.
 func (m *ServoMotor) MaxPulseSetpoint() (int, error) {
-	if m.err != nil {
-		return -1, m.Err()
-	}
-	b, err := ioutil.ReadFile(fmt.Sprintf(ServoMotorPath+"/%s/"+maxPulseSetpoint, m))
-	if err != nil {
-		return -1, fmt.Errorf("ev3dev: failed to read max pulse set point: %v", err)
-	}
-	sp, err := strconv.Atoi(string(chomp(b)))
-	if err != nil {
-		return -1, fmt.Errorf("ev3dev: failed to parse max pulse set point: %v", err)
-	}
-	return sp, nil
+	return intFrom(attributeOf(m, maxPulseSetpoint))
 }
 
-// SetMaxPulseSetpoint sets the max pulse set point value for the ServoMotor
+// SetMaxPulseSetpoint sets the max pulse setpoint value for the ServoMotor
 func (m *ServoMotor) SetMaxPulseSetpoint(sp int) *ServoMotor {
 	if m.err != nil {
 		return m
 	}
 	if sp < 2300 || sp > 2700 {
-		m.err = fmt.Errorf("ev3dev: invalid max pulse set point: %d (valid 2300-1700)", sp)
+		m.err = fmt.Errorf("ev3dev: invalid max pulse setpoint: %d (valid 2300-1700)", sp)
 		return m
 	}
-	err := m.writeFile(fmt.Sprintf(ServoMotorPath+"/%s/"+maxPulseSetpoint, m), fmt.Sprintln(sp))
-	if err != nil {
-		m.err = fmt.Errorf("ev3dev: failed to set max pulse set point: %v", err)
-	}
+	m.err = setAttributeOf(m, maxPulseSetpoint, string(sp))
 	return m
 }
 
-// MidPulseSetpoint returns the current mid pulse set point value for the ServoMotor.
+// MidPulseSetpoint returns the current mid pulse setpoint value for the ServoMotor.
 func (m *ServoMotor) MidPulseSetpoint() (int, error) {
-	if m.err != nil {
-		return -1, m.Err()
-	}
-	b, err := ioutil.ReadFile(fmt.Sprintf(ServoMotorPath+"/%s/"+midPulseSetpoint, m))
-	if err != nil {
-		return -1, fmt.Errorf("ev3dev: failed to read mid pulse set point: %v", err)
-	}
-	sp, err := strconv.Atoi(string(chomp(b)))
-	if err != nil {
-		return -1, fmt.Errorf("ev3dev: failed to parse mid pulse set point: %v", err)
-	}
-	return sp, nil
+	return intFrom(attributeOf(m, midPulseSetpoint))
 }
 
-// SetMidPulseSetpoint sets the mid pulse set point value for the ServoMotor
+// SetMidPulseSetpoint sets the mid pulse setpoint value for the ServoMotor
 func (m *ServoMotor) SetMidPulseSetpoint(sp int) *ServoMotor {
 	if m.err != nil {
 		return m
 	}
 	if sp < 1300 || sp > 1700 {
-		m.err = fmt.Errorf("ev3dev: invalid mid pulse set point: %d (valid 1300-1700)", sp)
+		m.err = fmt.Errorf("ev3dev: invalid mid pulse setpoint: %d (valid 1300-1700)", sp)
 		return m
 	}
-	err := m.writeFile(fmt.Sprintf(ServoMotorPath+"/%s/"+midPulseSetpoint, m), fmt.Sprintln(sp))
-	if err != nil {
-		m.err = fmt.Errorf("ev3dev: failed to set mid pulse set point: %v", err)
-	}
+	m.err = setAttributeOf(m, midPulseSetpoint, string(sp))
 	return m
 }
 
-// MinPulseSetpoint returns the current min pulse set point value for the ServoMotor.
+// MinPulseSetpoint returns the current min pulse setpoint value for the ServoMotor.
 func (m *ServoMotor) MinPulseSetpoint() (int, error) {
-	if m.err != nil {
-		return -1, m.Err()
-	}
-	b, err := ioutil.ReadFile(fmt.Sprintf(ServoMotorPath+"/%s/"+minPulseSetpoint, m))
-	if err != nil {
-		return -1, fmt.Errorf("ev3dev: failed to read min pulse set point: %v", err)
-	}
-	sp, err := strconv.Atoi(string(chomp(b)))
-	if err != nil {
-		return -1, fmt.Errorf("ev3dev: failed to parse min pulse set point: %v", err)
-	}
-	return sp, nil
+	return intFrom(attributeOf(m, minPulseSetpoint))
 }
 
-// SetMinPulseSetpoint sets the min pulse set point value for the ServoMotor
+// SetMinPulseSetpoint sets the min pulse setpoint value for the ServoMotor
 func (m *ServoMotor) SetMinPulseSetpoint(sp int) *ServoMotor {
 	if m.err != nil {
 		return m
 	}
 	if sp < 300 || sp > 700 {
-		m.err = fmt.Errorf("ev3dev: invalid min pulse set point: %d (valid 300 - 700)", sp)
+		m.err = fmt.Errorf("ev3dev: invalid min pulse setpoint: %d (valid 300 - 700)", sp)
 		return m
 	}
-	err := m.writeFile(fmt.Sprintf(ServoMotorPath+"/%s/"+minPulseSetpoint, m), fmt.Sprintln(sp))
-	if err != nil {
-		m.err = fmt.Errorf("ev3dev: failed to set min pulse set point: %v", err)
-	}
+	m.err = setAttributeOf(m, minPulseSetpoint, string(sp))
 	return m
 }
 
 // Polarity returns the current polarity of the ServoMotor.
-func (m *ServoMotor) Polarity() (string, error) {
-	if m.err != nil {
-		return "", m.Err()
-	}
-	b, err := ioutil.ReadFile(fmt.Sprintf(ServoMotorPath+"/%s/"+polarity, m))
-	if err != nil {
-		return "", fmt.Errorf("ev3dev: failed to read polarity: %v", err)
-	}
-	return string(b), nil
+func (m *ServoMotor) Polarity() (Polarity, error) {
+	p, err := stringFrom(attributeOf(m, polarity))
+	return Polarity(p), err
 }
 
 // SetPolarity sets the polarity of the ServoMotor
@@ -205,70 +148,44 @@ func (m *ServoMotor) SetPolarity(p Polarity) *ServoMotor {
 		m.err = fmt.Errorf("ev3dev: invalid polarity: %q (valid \"normal\" or \"inversed\")", p)
 		return m
 	}
-	err := m.writeFile(fmt.Sprintf(ServoMotorPath+"/%s/"+polarity, m), string(p))
-	if err != nil {
-		m.err = fmt.Errorf("ev3dev: failed to set polarity %v", err)
-	}
+	m.err = setAttributeOf(m, polarity, string(p))
 	return m
 }
 
-// Position returns the current position value for the ServoMotor.
-func (m *ServoMotor) Position() (int, error) {
-	if m.err != nil {
-		return -1, m.Err()
-	}
-	b, err := ioutil.ReadFile(fmt.Sprintf(ServoMotorPath+"/%s/"+position, m))
-	if err != nil {
-		return -1, fmt.Errorf("ev3dev: failed to read position: %v", err)
-	}
-	pos, err := strconv.Atoi(string(chomp(b)))
-	if err != nil {
-		return -1, fmt.Errorf("ev3dev: failed to parse position: %v", err)
-	}
-	return pos, nil
+// PositionSetpoint returns the current position setpoint value for
+// the ServoMotor.
+func (m *ServoMotor) PositionSetpoint() (int, error) {
+	return intFrom(attributeOf(m, positionSetpoint))
 }
 
-// SetPosition sets the position value for the ServoMotor.
-func (m *ServoMotor) SetPosition(pos int) *ServoMotor {
+// SetPositionSetpoint sets the position value for the ServoMotor.
+func (m *ServoMotor) SetPositionSetpoint(sp int) *ServoMotor {
 	if m.err != nil {
 		return m
 	}
-	if pos != int(int32(pos)) {
-		m.err = fmt.Errorf("ev3dev: invalid position: %d (valid in int32)", pos)
+	if sp != int(int32(sp)) {
+		m.err = fmt.Errorf("ev3dev: invalid position: %d (valid in int32)", sp)
 		return m
 	}
-	err := m.writeFile(fmt.Sprintf(ServoMotorPath+"/%s/"+position, m), fmt.Sprintln(pos))
-	if err != nil {
-		m.err = fmt.Errorf("ev3dev: failed to set position: %v", err)
-	}
+	m.err = setAttributeOf(m, positionSetpoint, fmt.Sprintln(sp))
 	return m
 }
 
-// RateSetpoint returns the current rate set point value for the ServoMotor.
+// RateSetpoint returns the current rate setpoint value for the ServoMotor.
 func (m *ServoMotor) RateSetpoint() (time.Duration, error) {
-	if m.err != nil {
-		return -1, m.Err()
-	}
-	b, err := ioutil.ReadFile(fmt.Sprintf(ServoMotorPath+"/%s/"+rateSetpoint, m))
-	if err != nil {
-		return -1, fmt.Errorf("ev3dev: failed to read rate set point: %v", err)
-	}
-	d, err := strconv.Atoi(string(chomp(b)))
-	if err != nil {
-		return -1, fmt.Errorf("ev3dev: failed to parse rate set point: %v", err)
-	}
-	return time.Duration(d) * time.Millisecond, nil
+	return durationFrom(attributeOf(m, rateSetpoint))
 }
 
-// SetRateSetpoint sets the rate set point value for the ServoMotor.
-func (m *ServoMotor) SetRateSetpoint(d time.Duration) *ServoMotor {
+// SetRateSetpoint sets the rate setpoint value for the ServoMotor.
+func (m *ServoMotor) SetRateSetpoint(sp time.Duration) *ServoMotor {
 	if m.err != nil {
 		return m
 	}
-	err := m.writeFile(fmt.Sprintf(ServoMotorPath+"/%s/"+rateSetpoint, m), fmt.Sprintln(int(d/time.Millisecond)))
-	if err != nil {
-		m.err = fmt.Errorf("ev3dev: failed to set rate set point: %v", err)
+	if sp < 0 {
+		m.err = fmt.Errorf("ev3dev: invalid ramp up setpoint: %v (must be positive)", sp)
+		return m
 	}
+	m.err = setAttributeOf(m, rateSetpoint, fmt.Sprintln(int(sp/time.Millisecond)))
 	return m
 }
 
@@ -277,13 +194,17 @@ func (m *ServoMotor) State() (MotorState, error) {
 	if m.err != nil {
 		return 0, m.Err()
 	}
-	b, err := ioutil.ReadFile(fmt.Sprintf(ServoMotorPath+"/%s/"+commands, m))
+	data, _, err := attributeOf(m, state)
 	if err != nil {
-		return 0, fmt.Errorf("ev3dev: failed to read servo-motor commands: %v", err)
+		return 0, err
 	}
 	var stat MotorState
-	for _, s := range strings.Split(string(chomp(b)), " ") {
-		stat |= motorStateTable[s]
+	for _, s := range strings.Split(data, " ") {
+		bit, ok := motorStateTable[s]
+		if !ok {
+			return 0, fmt.Errorf("ev3dev: unrecognized motor state value: %s in [%s]", s, data)
+		}
+		stat |= bit
 	}
 	return stat, nil
 }


### PR DESCRIPTION
This gives a significant line count reductions and makes mocking in a vsysfs a great deal easier for testing. Not all direct file accesses have been handed to generic functions.

Also fix typos, bugs and omissions.